### PR TITLE
Support for timeouts. FL-1586

### DIFF
--- a/Cache/RedisCache.php
+++ b/Cache/RedisCache.php
@@ -3,6 +3,7 @@
 namespace Igniter\ElastiCacheBundle\Cache;
 
 use Doctrine\Common\Cache\Cache;
+use Psr\Log\LoggerInterface;
 use Redis;
 
 /**
@@ -12,44 +13,55 @@ use Redis;
  */
 class RedisCache extends \Doctrine\Common\Cache\RedisCache
 {
-    /** @var \Redis */
-    private $master;
-    /** @var array of \Redis */
-    private $slaves = [];
+    /** @var array Host, port and timeout for connecting to Redis write server. */
+    private $writeConfig = [];
+    /** @var array[] Host, port and timeout for connecting to Redis write server. */
+    private $readConfigs = [];
+    /** @var Redis */
+    private $write;
+    /** @var Redis */
+    private $read;
+    /** @var LoggerInterface */
+    private $logger;
 
     /**
-     * @param \Redis $redis
+     * @param LoggerInterface|null $logger
      */
-    public function setMaster(Redis $redis)
+    public function __construct(LoggerInterface $logger = null)
     {
-        $redis->setOption(Redis::OPT_SERIALIZER, $this->getSerializerValue());
-        $this->master = $redis;
+        $this->logger = $logger;
     }
 
     /**
-     * @param \Redis $redis
+     * @param Redis $redis
+     * @param $host
+     * @param $port
+     * @param float $timeout
      */
-    public function addSlave(Redis $redis)
+    public function addRead(Redis $redis, $host, $port, $timeout = 0.0)
     {
-        $redis->setOption(Redis::OPT_SERIALIZER, $this->getSerializerValue());
-        $this->slaves[] = $redis;
+        $this->readConfigs[] = [
+            'redis' => $redis,
+            'host' => $host,
+            'port' => $port,
+            'timeout' => $timeout,
+        ];
     }
 
     /**
-     * @return \Redis
+     * @param Redis $redis
+     * @param $host
+     * @param $port
+     * @param float $timeout
      */
-    public function getMaster()
+    public function setWrite(Redis $redis, $host, $port, $timeout = 0.0)
     {
-        return $this->master;
-    }
-
-    /**
-     * Retrieve a random slave from the list.
-     * @return \Redis
-     */
-    public function getSlave()
-    {
-        return $this->slaves[array_rand($this->slaves)];
+        $this->writeConfig = [
+            'redis' => $redis,
+            'host' => $host,
+            'port' => $port,
+            'timeout' => $timeout,
+        ];
     }
 
     /**
@@ -57,7 +69,7 @@ class RedisCache extends \Doctrine\Common\Cache\RedisCache
      */
     protected function doFetch($id)
     {
-        return $this->getSlave()->get($id);
+        return $this->getRead()->get($id);
     }
 
     /**
@@ -65,7 +77,7 @@ class RedisCache extends \Doctrine\Common\Cache\RedisCache
      */
     protected function doContains($id)
     {
-        return $this->getSlave()->exists($id);
+        return $this->getRead()->exists($id);
     }
 
     /**
@@ -74,10 +86,10 @@ class RedisCache extends \Doctrine\Common\Cache\RedisCache
     protected function doSave($id, $data, $lifeTime = 0)
     {
         if ($lifeTime > 0) {
-            return $this->getMaster()->setex($id, $lifeTime, $data);
+            return $this->getWrite()->setex($id, $lifeTime, $data);
         }
 
-        return $this->getMaster()->set($id, $data);
+        return $this->getWrite()->set($id, $data);
     }
 
     /**
@@ -85,7 +97,7 @@ class RedisCache extends \Doctrine\Common\Cache\RedisCache
      */
     protected function doDelete($id)
     {
-        return $this->getMaster()->delete($id) > 0;
+        return $this->getWrite()->delete($id) > 0;
     }
 
     /**
@@ -93,7 +105,7 @@ class RedisCache extends \Doctrine\Common\Cache\RedisCache
      */
     protected function doFlush()
     {
-        return $this->getMaster()->flushDB();
+        return $this->getWrite()->flushDB();
     }
 
     /**
@@ -101,7 +113,7 @@ class RedisCache extends \Doctrine\Common\Cache\RedisCache
      */
     protected function doGetStats()
     {
-        $info = $this->getMaster()->info();
+        $info = $this->getWrite()->info();
 
         return array(
             Cache::STATS_HITS => false,
@@ -110,5 +122,57 @@ class RedisCache extends \Doctrine\Common\Cache\RedisCache
             Cache::STATS_MEMORY_USAGE => $info['used_memory'],
             Cache::STATS_MEMORY_AVAILABLE => false
         );
+    }
+
+    /**
+     * Retrieve a random read replica from the list.
+     * @return \Redis
+     * @throws \RedisException
+     */
+    private function getRead()
+    {
+        if (!$this->read) {
+            shuffle($this->readConfigs);
+            foreach ($this->readConfigs as $config) {
+                /** @var \Redis $redis */
+                $redis = $config['redis'];
+                try {
+                    $redis->connect($config['host'], $config['port'], $config['timeout']);
+                    $redis->setOption(Redis::OPT_SERIALIZER, $this->getSerializerValue());
+                    $this->read = $redis;
+                    break;
+                }
+                catch (\RedisException $ex) {
+                    if ($this->logger) {
+                        $this->logger->warning('Failed to connect to a Redis read replica.', [
+                            'exception' => $ex,
+                            'host' => $config['host'],
+                            'port' => $config['port'],
+                        ]);
+                    }
+                }
+            }
+
+            // If we failed to connect to any read replicas, give up, and send back the last exception (if any)
+            if (!$this->read) {
+                throw new \RedisException('Failed to connect to any Redis read replicas.', 0, isset($ex) ? $ex : null);
+            }
+        }
+
+        return $this->read;
+    }
+
+    /**
+     * @return \Redis
+     */
+    private function getWrite()
+    {
+        if (!$this->write) {
+            $this->write = $this->writeConfig['redis'];
+            $this->write->connect($this->writeConfig['host'], $this->writeConfig['port'], $this->writeConfig['timeout']);
+            $this->write->setOption(Redis::OPT_SERIALIZER, $this->getSerializerValue());
+        }
+
+        return $this->write;
     }
 }

--- a/DependencyInjection/Compiler/RedisCompiler.php
+++ b/DependencyInjection/Compiler/RedisCompiler.php
@@ -36,14 +36,12 @@ class RedisCompiler implements CompilerPassInterface
         foreach ($servers as $server) {
             // Create a definition for each Redis object
             $redis_definition = new Definition($redis_classname);
-            // Tell it to connect when used
-            $redis_definition->addMethodCall('connect', [$server['host'], $server['port']]);
 
             // Add to the RedisCache provider
             if (isset($server['master']) && $server['master']) {
-                $definition->addMethodCall('setMaster', [$redis_definition]);
+                $definition->addMethodCall('setWrite', [$redis_definition, $server['host'], $server['port'], isset($server['timeout']) ? $server['timeout'] : 0.0]);
             } else {
-                $definition->addMethodCall('addSlave', [$redis_definition]);
+                $definition->addMethodCall('addRead', [$redis_definition, $server['host'], $server['port'], isset($server['timeout']) ? $server['timeout'] : 0.0]);
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ElastiCacheBundle
 An ElastiCache Bundle for Symfony. This could also be used for Redis Clusters that aren't in ElastiCache as well. To that end, we use typical "master" and "slave" nomenclature instead of ElastiCache's "primary" and "read" node names.
 
 [![Codeship Status for ShopIgniter/ElastiCacheBundle](https://codeship.io/projects/fba198c0-f3ed-0131-a47e-6a1bcd925291/status?branch=master)](https://codeship.io/projects/27992)
-[![Coverage Status](https://img.shields.io/coveralls/ShopIgniter/ElastiCacheBundle.svg)](https://coveralls.io/r/ShopIgniter/ElastiCacheBundle)
+[![Coverage Status](https://coveralls.io/repos/Mixpo/ElastiCacheBundle/badge.svg?branch=master&service=github)](https://coveralls.io/github/Mixpo/ElastiCacheBundle?branch=master)
 
 ## Installation
 
@@ -13,9 +13,9 @@ To enable the RedisCache service, add your servers to your parameters.yml.
 parameters:
     # ...
     cache.redis.servers:
-        - { host: primary-write.ng.amazonaws.example.com, port: 6379, master: true }
-        - { host: primary-read.amazonaws.example.com, port: 6379 }
-        - { host: read-1.amazonaws.example.com, port: 6379 }
+        - { host: primary-write.ng.amazonaws.example.com, port: 6379, master: true, timeout: 5 }
+        - { host: primary-read.amazonaws.example.com, port: 6379, timeout: 5 }
+        - { host: read-1.amazonaws.example.com, port: 6379, timeout: 5 }
 ```
 
 ### Notes

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,3 +5,4 @@ parameters:
 services:
     igniter.elasticache.rediscache:
         class: "%igniter.elasticache.rediscache.class%"
+        arguments: [@?logger]

--- a/Tests/Cache/RedisCacheTest.php
+++ b/Tests/Cache/RedisCacheTest.php
@@ -16,131 +16,240 @@ class RedisCacheTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->node1Mock = $this->getMock('Redis');
+        $this->node1Mock = $this->getMockBuilder('Redis')
+            ->setMethods(['setOption', 'connect', 'get', 'set', 'setex', 'exists', 'delete', 'info', 'flushDB'])
+            ->getMock();
         $this->node2Mock = $this->getMock('Redis');
     }
 
-    protected function tearDown()
+    public function testSetWrite()
     {
-        $this->node1Mock = null;
-        $this->node2Mock = null;
-    }
+        $this->node1Mock->expects($this->never())
+            ->method('setOption');
+        $this->node1Mock->expects($this->never())
+            ->method('connect');
 
-    public function testSetMaster()
+        $redis = new RedisCache();
+        $redis->setWrite($this->node1Mock, 'localhost', 1234);
+    }
+    public function testAddRead()
+    {
+        $this->node1Mock->expects($this->never())
+            ->method('setOption');
+        $this->node1Mock->expects($this->never())
+            ->method('connect');
+
+        $redis = new RedisCache();
+        $redis->addRead($this->node1Mock, 'localhost', 1234);
+    }
+    public function testGetRead()
     {
         $this->node1Mock->expects($this->once())
             ->method('setOption')
             ->with(\Redis::OPT_SERIALIZER, $this->isType('int'));
+        $this->node1Mock->expects($this->once())
+            ->method('connect')
+            ->with('localhost', 1234, 0.0);
+
+        // make private public
+        $method = new \ReflectionMethod('Igniter\ElastiCacheBundle\Cache\RedisCache', 'getRead');
+        $method->setAccessible(true);
 
         $redis = new RedisCache();
-        $redis->setMaster($this->node1Mock);
+        $redis->addRead($this->node1Mock, 'localhost', 1234);
 
-        $this->assertEquals($this->node1Mock, $redis->getMaster());
+        $this->assertEquals($this->node1Mock, $method->invoke($redis));
     }
-
-    public function testAddSlave()
+    public function testGetReadWithTimeout()
     {
         $this->node1Mock->expects($this->once())
             ->method('setOption')
             ->with(\Redis::OPT_SERIALIZER, $this->isType('int'));
+        $this->node1Mock->expects($this->once())
+            ->method('connect')
+            ->with('localhost', 1234, 4);
+
+        // make private public
+        $method = new \ReflectionMethod('Igniter\ElastiCacheBundle\Cache\RedisCache', 'getRead');
+        $method->setAccessible(true);
 
         $redis = new RedisCache();
-        $redis->addSlave($this->node1Mock);
+        $redis->addRead($this->node1Mock, 'localhost', 1234, 4);
 
-        $this->assertEquals($this->node1Mock, $redis->getSlave());
+        $this->assertEquals($this->node1Mock, $method->invoke($redis));
     }
-
-    public function testGetSlave()
+    public function testGetReadFromMultiple()
     {
         $this->node1Mock->expects($this->once())
             ->method('setOption')
             ->with(\Redis::OPT_SERIALIZER, $this->isType('int'));
+        $this->node1Mock->expects($this->once())
+            ->method('connect');
+
+        // make private public
+        $method = new \ReflectionMethod('Igniter\ElastiCacheBundle\Cache\RedisCache', 'getRead');
+        $method->setAccessible(true);
 
         $redis = new RedisCache();
-        $redis->addSlave($this->node1Mock);
+        $redis->addRead($this->node1Mock, 'localhost', 1234);
+        $redis->addRead($this->node1Mock, 'localhost', 12345);
 
-        // todo maybe should flush out how to ensure we get a random slave?
-        $this->assertEquals($this->node1Mock, $redis->getSlave());
+        $this->assertEquals($this->node1Mock, $method->invoke($redis));
     }
+    public function testGetReadAlwaysSucceedWhenOneFailsToConnect()
+    {
+        $this->node1Mock->expects($this->once())
+            ->method('setOption')
+            ->with(\Redis::OPT_SERIALIZER, $this->isType('int'));
+        $this->node1Mock->expects($this->exactly(2))
+            ->method('connect')
+            ->withConsecutive($this->logicalOr(
+                ['localhost', 1234, 0.0],
+                ['localhost', 12345, 0.0]
+            ))
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new \RedisException('Test exception')),
+                true
+            );
 
+        // make private public
+        $method = new \ReflectionMethod('Igniter\ElastiCacheBundle\Cache\RedisCache', 'getRead');
+        $method->setAccessible(true);
+
+        $redis = new RedisCache();
+        $redis->addRead($this->node1Mock, 'localhost', 1234);
+        $redis->addRead($this->node1Mock, 'localhost', 12345);
+
+        $method->invoke($redis);
+        $this->assertEquals($this->node1Mock, $method->invoke($redis));
+    }
+    public function testGetReadLogsWhenUnableToConnect()
+    {
+        $this->node1Mock->expects($this->never())
+            ->method('setOption');
+        $this->node1Mock->expects($this->once())
+            ->method('connect')
+            ->with('localhost', 1234, 0.0)
+            ->willThrowException(new \RedisException('Test exception'));
+        $logger = $this->getMock('Psr\Log\NullLogger');
+        $logger->expects($this->once())
+            ->method('warning');
+
+        // make private public
+        $method = new \ReflectionMethod('Igniter\ElastiCacheBundle\Cache\RedisCache', 'getRead');
+        $method->setAccessible(true);
+
+        $redis = new RedisCache($logger);
+        $redis->addRead($this->node1Mock, 'localhost', 1234);
+
+        $this->setExpectedException('RedisException');
+        $method->invoke($redis);
+    }
+    public function testGetReadNoServersExist()
+    {
+        // make private public
+        $method = new \ReflectionMethod('Igniter\ElastiCacheBundle\Cache\RedisCache', 'getRead');
+        $method->setAccessible(true);
+
+        $redis = new RedisCache();
+
+        $this->setExpectedException('RedisException');
+        $method->invoke($redis);
+    }
+    public function testGetReadThrowWhenFailedToConnect()
+    {
+        $this->node1Mock->expects($this->never())
+            ->method('setOption');
+        $this->node1Mock->expects($this->once())
+            ->method('connect')
+            ->willThrowException(new \RedisException('Test exception'));
+
+        // make private public
+        $method = new \ReflectionMethod('Igniter\ElastiCacheBundle\Cache\RedisCache', 'getRead');
+        $method->setAccessible(true);
+
+        $redis = new RedisCache();
+        $redis->addRead($this->node1Mock, 'localhost', 1234);
+
+        $this->setExpectedException('RedisException', 'Failed to connect to any Redis read replicas.');
+        $method->invoke($redis);
+    }
     public function testFetch()
     {
         $this->node1Mock->expects($this->once())
             ->method('setOption')
             ->with(\Redis::OPT_SERIALIZER, $this->isType('int'));
-
-        $this->node1Mock->expects($this->at(1))
+        $this->node1Mock->expects($this->exactly(2))
             ->method('get')
-            ->with("DoctrineNamespaceCacheKey[{$this->namespace}]")
-            ->will($this->returnValue(1));
-        $this->node1Mock->expects($this->at(2))
-            ->method('get')
-            ->with("{$this->namespace}[foo][1]")
-            ->will($this->returnValue('bar'));
+            ->withConsecutive(
+                ["DoctrineNamespaceCacheKey[{$this->namespace}]"],
+                ["{$this->namespace}[foo][1]"]
+            )
+            ->willReturnOnConsecutiveCalls(
+                1,
+                'bar'
+            );
 
         $redis = new RedisCache();
         $redis->setNamespace($this->namespace);
-        $redis->addSlave($this->node1Mock);
+        $redis->addRead($this->node1Mock, 'localhost', 1234);
 
         $this->assertEquals('bar', $redis->fetch('foo'));
     }
-
     public function testContains()
     {
         $this->node1Mock->expects($this->once())
             ->method('setOption')
             ->with(\Redis::OPT_SERIALIZER, $this->isType('int'));
 
-        $this->node1Mock->expects($this->at(1))
+        $this->node1Mock->expects($this->once())
             ->method('get')
             ->with("DoctrineNamespaceCacheKey[{$this->namespace}]")
-            ->will($this->returnValue(1));
-        $this->node1Mock->expects($this->at(2))
+            ->willReturn(1);
+        $this->node1Mock->expects($this->once())
             ->method('exists')
             ->with("{$this->namespace}[foo][1]")
             ->will($this->returnValue(true));
 
         $redis = new RedisCache();
         $redis->setNamespace($this->namespace);
-        $redis->addSlave($this->node1Mock);
+        $redis->addRead($this->node1Mock, 'localhost', 1234);
 
         $this->assertTrue($redis->contains('foo'));
     }
-
     public function testSave()
     {
         // slave
         $this->node2Mock->expects($this->once())
             ->method('setOption')
             ->with(\Redis::OPT_SERIALIZER, $this->isType('int'));
-        $this->node2Mock->expects($this->at(1))
+        $this->node2Mock->expects($this->once())
             ->method('get')
             ->with("DoctrineNamespaceCacheKey[{$this->namespace}]")
-            ->will($this->returnValue(1));
+            ->willReturn(1);
         // master
         $this->node1Mock->expects($this->once())
             ->method('setOption')
             ->with(\Redis::OPT_SERIALIZER, $this->isType('int'));
-        $this->node1Mock->expects($this->at(1))
+        $this->node1Mock->expects($this->once())
             ->method('set')
             ->with("{$this->namespace}[foo][1]", 'bam')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $redis = new RedisCache();
         $redis->setNamespace($this->namespace);
-        $redis->setMaster($this->node1Mock);
-        $redis->addSlave($this->node2Mock);
+        $redis->setWrite($this->node1Mock, 'localhost', 1234);
+        $redis->addRead($this->node2Mock, 'localhost', 12345);
 
         $this->assertTrue($redis->save('foo', 'bam'));
     }
-
     public function testSaveTtl()
     {
         // slave
         $this->node2Mock->expects($this->once())
             ->method('setOption')
             ->with(\Redis::OPT_SERIALIZER, $this->isType('int'));
-        $this->node2Mock->expects($this->at(1))
+        $this->node2Mock->expects($this->once())
             ->method('get')
             ->with("DoctrineNamespaceCacheKey[{$this->namespace}]")
             ->will($this->returnValue(1));
@@ -148,63 +257,60 @@ class RedisCacheTest extends \PHPUnit_Framework_TestCase
         $this->node1Mock->expects($this->once())
             ->method('setOption')
             ->with(\Redis::OPT_SERIALIZER, $this->isType('int'));
-        $this->node1Mock->expects($this->at(1))
+        $this->node1Mock->expects($this->once())
             ->method('setex')
             ->with("{$this->namespace}[foo][1]", 1, 'bam')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $redis = new RedisCache();
         $redis->setNamespace($this->namespace);
-        $redis->setMaster($this->node1Mock);
-        $redis->addSlave($this->node2Mock);
+        $redis->setWrite($this->node1Mock, 'localhost', 1234);
+        $redis->addRead($this->node2Mock, 'localhost', 12345);
 
         $this->assertTrue($redis->save('foo', 'bam', 1));
     }
-
     public function testDelete()
     {
         // slave
         $this->node2Mock->expects($this->once())
             ->method('setOption')
             ->with(\Redis::OPT_SERIALIZER, $this->isType('int'));
-        $this->node2Mock->expects($this->at(1))
+        $this->node2Mock->expects($this->once())
             ->method('get')
             ->with("DoctrineNamespaceCacheKey[{$this->namespace}]")
-            ->will($this->returnValue(1));
+            ->willReturn(1);
         // master
         $this->node1Mock->expects($this->once())
             ->method('setOption')
             ->with(\Redis::OPT_SERIALIZER, $this->isType('int'));
-        $this->node1Mock->expects($this->at(1))
+        $this->node1Mock->expects($this->once())
             ->method('delete')
             ->with("{$this->namespace}[foo][1]")
-            ->will($this->returnValue(1));
+            ->willReturn(true);
 
         $redis = new RedisCache();
         $redis->setNamespace($this->namespace);
-        $redis->setMaster($this->node1Mock);
-        $redis->addSlave($this->node2Mock);
+        $redis->setWrite($this->node1Mock, 'localhost', 1234);
+        $redis->addRead($this->node2Mock, 'localhost', 12345);
 
         $this->assertTrue($redis->delete('foo'));
     }
-
     public function testFlush()
     {
         // master
         $this->node1Mock->expects($this->once())
             ->method('setOption')
             ->with(\Redis::OPT_SERIALIZER, $this->isType('int'));
-        $this->node1Mock->expects($this->at(1))
+        $this->node1Mock->expects($this->once())
             ->method('flushDB')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $redis = new RedisCache();
         $redis->setNamespace($this->namespace);
-        $redis->setMaster($this->node1Mock);
+        $redis->setWrite($this->node1Mock, 'localhost', 1234);
 
         $this->assertTrue($redis->flushAll());
     }
-
     public function testGetStats()
     {
         $redis_info = [
@@ -215,12 +321,12 @@ class RedisCacheTest extends \PHPUnit_Framework_TestCase
         $this->node1Mock->expects($this->once())
             ->method('setOption')
             ->with(\Redis::OPT_SERIALIZER, $this->isType('int'));
-        $this->node1Mock->expects($this->at(1))
+        $this->node1Mock->expects($this->once())
             ->method('info')
-            ->will($this->returnValue($redis_info));
+            ->willReturn($redis_info);
 
         $redis = new RedisCache();
-        $redis->setMaster($this->node1Mock);
+        $redis->setWrite($this->node1Mock, 'localhost', 1234);
 
         $actual = $redis->getStats();
         $this->assertInternalType('array', $actual);

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,8 +1,0 @@
-<?php
-
-if (!is_file($autoloadFile = __DIR__ . '/../vendor/autoload.php')) {
-    throw new \LogicException('Could not find autoload.php in ./vendor. Did you `composer install`?');
-}
-
-/** @var \Composer\Autoload\ClassLoader $loader */
-$loader = require $autoloadFile;

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,15 @@
   },
   "require": {
     "php": ">=5.5",
-    "symfony/framework-bundle": "~2.4",
-    "symfony/yaml": "~2.4",
+    "symfony/framework-bundle": "~2.7",
+    "symfony/yaml": "~2.7",
     "doctrine/cache": "~1.3",
-    "doctrine/doctrine-cache-bundle": "~1.0"
+    "doctrine/doctrine-cache-bundle": "~1.0",
+    "psr/log": "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~3.7",
+    "symfony/expression-language": "~2.7",
+    "phpunit/phpunit": "~4.0",
     "satooshi/php-coveralls": "dev-master"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit
-    bootstrap="./Tests/bootstrap.php"
-    colors="false"
-    stopOnFailure="false">
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         bootstrap="./vendor/autoload.php"
+>
 
     <testsuites>
         <testsuite name="ElastiCacheBundle Test Suite">


### PR DESCRIPTION
- Allow a timeout to be specified per-redis instance.
- Only connect when attempting to read/write to Redis.
- Use only one read replica for a single instance of RedisCache for the request.
- Added logging for read replica connection failures.
- Removed racism (master/slave -> write/read).
